### PR TITLE
Escaped single quotes to fix build errors

### DIFF
--- a/src/components/Services.js
+++ b/src/components/Services.js
@@ -52,8 +52,8 @@ const Services = () => {
                 <h5>Laravel</h5>
                 <p>
                   Laravel has been an absolute breeze to work with.
-                  I'm working with it currently and feel the documentation
-                  is among the best I've ever seen.
+                  {`I'm`} working with it currently and feel the documentation
+                  is among the best {`I've`} ever seen.
                 </p>
               </div>
             </div>


### PR DESCRIPTION
Additions:
N/a.

Changes:
* Escaped two contractions that used single quotes - were causing build failure.

Removals:
N/a.